### PR TITLE
Use UUIDs instead of player names.

### DIFF
--- a/.idea/libraries/nChat.xml
+++ b/.idea/libraries/nChat.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="nChat">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/../out/nChat.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="file://$PROJECT_DIR$/../nChat/src" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
+  <component name="ASMPluginConfiguration">
+    <asm skipDebug="false" skipFrames="false" skipCode="false" expandFrames="false" />
+    <groovy codeStyle="LEGACY" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
-

--- a/ant.xml
+++ b/ant.xml
@@ -27,7 +27,7 @@
     <target name="compile" depends="clean">
         <buildnumber/>
         <mkdir dir="${classes.dir}"/>
-        <javac srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" debug="true" debuglevel="lines,vars,source" deprecation="true"/>
+        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" debug="true" debuglevel="lines,vars,source" deprecation="true"/>
     </target>
 
     <target name="jar" depends="compile,injectVersion">

--- a/src/no/runsafe/clans/Clan.java
+++ b/src/no/runsafe/clans/Clan.java
@@ -1,11 +1,13 @@
 package no.runsafe.clans;
 
+import no.runsafe.framework.api.player.IPlayer;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class Clan
 {
-	public Clan(String id, String leader, String motd)
+	public Clan(String id, IPlayer leader, String motd)
 	{
 		this.id = id;
 		this.leader = leader;
@@ -22,7 +24,7 @@ public class Clan
 		this.motd = motd;
 	}
 
-	public void setLeader(String leader)
+	public void setLeader(IPlayer leader)
 	{
 		this.leader = leader;
 	}
@@ -32,12 +34,12 @@ public class Clan
 		return id;
 	}
 
-	public String getLeader()
+	public IPlayer getLeader()
 	{
 		return leader;
 	}
 
-	public List<String> getMembers()
+	public List<IPlayer> getMembers()
 	{
 		return members;
 	}
@@ -47,14 +49,14 @@ public class Clan
 		return members.size();
 	}
 
-	public void addMember(String playerName)
+	public void addMember(IPlayer player)
 	{
-		members.add(playerName);
+		members.add(player);
 	}
 
-	public void removeMember(String playerName)
+	public void removeMember(IPlayer player)
 	{
-		members.remove(playerName);
+		members.remove(player);
 	}
 
 	public void addClanKills(int amount)
@@ -88,10 +90,10 @@ public class Clan
 	}
 
 	private final String id;
-	private String leader;
+	private IPlayer leader;
 	private String motd;
 	private int clanKills = 0;
 	private int clanDeaths = 0;
 	private int dergonKills = 0;
-	private final List<String> members = new ArrayList<String>(0);
+	private final List<IPlayer> members = new ArrayList<IPlayer>(0);
 }

--- a/src/no/runsafe/clans/Config.java
+++ b/src/no/runsafe/clans/Config.java
@@ -3,12 +3,26 @@ package no.runsafe.clans;
 import no.runsafe.framework.api.IConfiguration;
 import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public class Config implements IConfigurationChanged
 {
 	@Override
 	public void OnConfigurationChanged(IConfiguration configuration)
 	{
+		// Get maximum clan size.
 		clanSize = configuration.getConfigValueAsInt("clanSize");
+
+		// Get clan score information.
+		clanMemberScore = configuration.getConfigValueAsInt("ranking.clanMember");
+		clanKillScore = configuration.getConfigValueAsInt("ranking.clanKill");
+		clanDergonKillScore = configuration.getConfigValueAsInt("ranking.dergonKill");
+
+		// Get all worlds in the clan universe.
+		clanUniverse.clear();
+		Collections.addAll(clanUniverse, configuration.getConfigValueAsString("clanUniverse").split(","));
 	}
 
 	public int getClanSize()
@@ -16,5 +30,29 @@ public class Config implements IConfigurationChanged
 		return clanSize;
 	}
 
+	public int getClanMemberScore()
+	{
+		return clanMemberScore;
+	}
+
+	public int getClanKillScore()
+	{
+		return clanKillScore;
+	}
+
+	public int getClanDergonKillScore()
+	{
+		return clanDergonKillScore;
+	}
+
+	public List<String> getClanUniverse()
+	{
+		return clanUniverse;
+	}
+
 	private int clanSize;
+	private int clanMemberScore;
+	private int clanKillScore;
+	private int clanDergonKillScore;
+	private List<String> clanUniverse = new ArrayList<String>(0);
 }

--- a/src/no/runsafe/clans/Config.java
+++ b/src/no/runsafe/clans/Config.java
@@ -15,11 +15,6 @@ public class Config implements IConfigurationChanged
 		// Get maximum clan size.
 		clanSize = configuration.getConfigValueAsInt("clanSize");
 
-		// Get clan score information.
-		clanMemberScore = configuration.getConfigValueAsInt("ranking.clanMember");
-		clanKillScore = configuration.getConfigValueAsInt("ranking.clanKill");
-		clanDergonKillScore = configuration.getConfigValueAsInt("ranking.dergonKill");
-
 		// Get all worlds in the clan universe.
 		clanUniverse.clear();
 		Collections.addAll(clanUniverse, configuration.getConfigValueAsString("clanUniverse").split(","));
@@ -30,29 +25,11 @@ public class Config implements IConfigurationChanged
 		return clanSize;
 	}
 
-	public int getClanMemberScore()
-	{
-		return clanMemberScore;
-	}
-
-	public int getClanKillScore()
-	{
-		return clanKillScore;
-	}
-
-	public int getClanDergonKillScore()
-	{
-		return clanDergonKillScore;
-	}
-
 	public List<String> getClanUniverse()
 	{
 		return clanUniverse;
 	}
 
 	private int clanSize;
-	private int clanMemberScore;
-	private int clanKillScore;
-	private int clanDergonKillScore;
 	private List<String> clanUniverse = new ArrayList<String>(0);
 }

--- a/src/no/runsafe/clans/commands/ClanFlare.java
+++ b/src/no/runsafe/clans/commands/ClanFlare.java
@@ -17,7 +17,7 @@ public class ClanFlare extends PlayerCommand
 	@Override
 	public String OnExecute(IPlayer executor, IArgumentList parameters)
 	{
-		if (!handler.playerIsInClan(executor.getName()))
+		if (!handler.playerIsInClan(executor))
 			return "&cYou are not in a clan.";
 
 		ILocation location = executor.getLocation();

--- a/src/no/runsafe/clans/commands/ClanInfo.java
+++ b/src/no/runsafe/clans/commands/ClanInfo.java
@@ -24,7 +24,7 @@ public class ClanInfo extends AsyncCommand
 	@Override
 	public String OnAsyncExecute(ICommandExecutor executor, IArgumentList parameters)
 	{
-		String clanName = parameters.get("clan").toUpperCase();
+		String clanName = ((String) parameters.getValue("clan")).toUpperCase();
 
 		if (!clanHandler.clanExists(clanName))
 			return "&cNo clan named '" + clanName + "' exists.";

--- a/src/no/runsafe/clans/commands/CreateClan.java
+++ b/src/no/runsafe/clans/commands/CreateClan.java
@@ -30,8 +30,7 @@ public class CreateClan extends PlayerAsyncCommand
 		if (clanHandler.clanExists(clanName))
 			return String.format("&cA clan named '%s' already exists.", clanName);
 
-		String playerName = executor.getName();
-		if (clanHandler.playerIsInClan(playerName))
+		if (clanHandler.playerIsInClan(executor))
 			return "&cYou are already in a clan!";
 
 		charterHandler.givePlayerCharter(executor, clanName); // Give them a charter.

--- a/src/no/runsafe/clans/commands/CreateClan.java
+++ b/src/no/runsafe/clans/commands/CreateClan.java
@@ -20,7 +20,7 @@ public class CreateClan extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String clanName = parameters.get("clanTag").toUpperCase();
+		String clanName = ((String) parameters.getValue("clanTag")).toUpperCase();
 
 		// Check we have been given a valid clan name.
 		if (clanHandler.isInvalidClanName(clanName))

--- a/src/no/runsafe/clans/commands/DeclineClan.java
+++ b/src/no/runsafe/clans/commands/DeclineClan.java
@@ -18,7 +18,7 @@ public class DeclineClan extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String clanName = parameters.get("clan").toUpperCase();
+		String clanName = ((String)parameters.getValue("clan")).toUpperCase();
 		if (clanHandler.playerHasPendingInvite(clanName, executor.getName()))
 		{
 			clanHandler.removePendingInvite(executor, clanName);

--- a/src/no/runsafe/clans/commands/DeclineClan.java
+++ b/src/no/runsafe/clans/commands/DeclineClan.java
@@ -19,7 +19,7 @@ public class DeclineClan extends PlayerAsyncCommand
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
 		String clanName = ((String)parameters.getValue("clan")).toUpperCase();
-		if (clanHandler.playerHasPendingInvite(clanName, executor.getName()))
+		if (clanHandler.playerHasPendingInvite(clanName, executor))
 		{
 			clanHandler.removePendingInvite(executor, clanName);
 			return "&cInvitation to " + clanName + " declined.";

--- a/src/no/runsafe/clans/commands/DisbandClan.java
+++ b/src/no/runsafe/clans/commands/DisbandClan.java
@@ -17,14 +17,13 @@ public class DisbandClan extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer player, IArgumentList parameters)
 	{
-		String playerName = player.getName();
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(player))
 			return "&cYou are not in a clan.";
 
-		if (!clanHandler.playerIsClanLeader(playerName))
+		if (!clanHandler.playerIsClanLeader(player))
 			return "&cYou are not the clan leader.";
 
-		clanHandler.disbandClan(clanHandler.getPlayerClan(playerName));
+		clanHandler.disbandClan(clanHandler.getPlayerClan(player));
 		return "&aYour clan has been disbanded.";
 	}
 

--- a/src/no/runsafe/clans/commands/InviteMember.java
+++ b/src/no/runsafe/clans/commands/InviteMember.java
@@ -21,22 +21,20 @@ public class InviteMember extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String playerName = executor.getName();
-
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(executor))
 			return "&cYou are not in a clan.";
 
-		if (!clanHandler.playerIsClanLeader(playerName))
+		if (!clanHandler.playerIsClanLeader(executor))
 			return "&cYou are not the clan leader, you cannot invite players.";
 
 		IPlayer targetPlayer = parameters.getValue("player") ;
 		if (targetPlayer == null)
 			return "&cInvalid player.";
 
-		if (clanHandler.playerIsInClan(targetPlayer.getName()))
+		if (clanHandler.playerIsInClan(targetPlayer))
 			return "&cThat player is already in a clan.";
 
-		Clan clan = clanHandler.getPlayerClan(playerName); // Grab the players clan.
+		Clan clan = clanHandler.getPlayerClan(executor); // Grab the players clan.
 
 		if (clan.getMemberCount() >= config.getClanSize())
 			return "&cYour clan is full! Remove someone before inviting more.";

--- a/src/no/runsafe/clans/commands/InviteMember.java
+++ b/src/no/runsafe/clans/commands/InviteMember.java
@@ -33,9 +33,7 @@ public class InviteMember extends PlayerAsyncCommand
 		if (targetPlayer == null)
 			return "&cInvalid player.";
 
-		String targetPlayerName = targetPlayer.getName();
-
-		if (clanHandler.playerIsInClan(targetPlayerName))
+		if (clanHandler.playerIsInClan(targetPlayer.getName()))
 			return "&cThat player is already in a clan.";
 
 		Clan clan = clanHandler.getPlayerClan(playerName); // Grab the players clan.
@@ -43,7 +41,7 @@ public class InviteMember extends PlayerAsyncCommand
 		if (clan.getMemberCount() >= config.getClanSize())
 			return "&cYour clan is full! Remove someone before inviting more.";
 
-		if (clanHandler.playerHasPendingInvite(clan.getId(), targetPlayerName))
+		if (clanHandler.playerHasPendingInvite(clan.getId(), targetPlayer))
 			return "&cThat player has already been invited to this clan.";
 
 		clanHandler.invitePlayerToClan(clan.getId(), targetPlayer); // Invite the player.

--- a/src/no/runsafe/clans/commands/JoinClan.java
+++ b/src/no/runsafe/clans/commands/JoinClan.java
@@ -21,7 +21,7 @@ public class JoinClan extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String clanName = parameters.get("clan").toUpperCase();
+		String clanName = ((String) parameters.getValue("clan")).toUpperCase();
 		if (clanHandler.playerHasPendingInvite(clanName, executor.getName()))
 		{
 			Clan clan = clanHandler.getClan(clanName);

--- a/src/no/runsafe/clans/commands/JoinClan.java
+++ b/src/no/runsafe/clans/commands/JoinClan.java
@@ -22,7 +22,7 @@ public class JoinClan extends PlayerAsyncCommand
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
 		String clanName = ((String) parameters.getValue("clan")).toUpperCase();
-		if (clanHandler.playerHasPendingInvite(clanName, executor.getName()))
+		if (clanHandler.playerHasPendingInvite(clanName, executor))
 		{
 			Clan clan = clanHandler.getClan(clanName);
 			if (clan.getMemberCount() >= config.getClanSize())

--- a/src/no/runsafe/clans/commands/KickClanMember.java
+++ b/src/no/runsafe/clans/commands/KickClanMember.java
@@ -19,11 +19,10 @@ public class KickClanMember extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String playerName = executor.getName();
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(executor))
 			return "&cYou are not in a clan.";
 
-		if (!clanHandler.playerIsClanLeader(playerName))
+		if (!clanHandler.playerIsClanLeader(executor))
 			return "&cYou are not the clan leader.";
 
 		IPlayer targetPlayer = parameters.getValue("player");
@@ -31,13 +30,12 @@ public class KickClanMember extends PlayerAsyncCommand
 		if (targetPlayer == null)
 			return "&cInvalid player.";
 
-		String targetPlayerName = targetPlayer.getName();
-		if (targetPlayerName.equals(playerName))
+		if (targetPlayer.equals(executor))
 			return "&cYou cannot kick yourself.";
 
-		Clan playerClan = clanHandler.getPlayerClan(playerName); // Grab the players clan.
+		Clan playerClan = clanHandler.getPlayerClan(executor); // Grab the players clan.
 
-		if (!clanHandler.playerIsInClan(targetPlayerName, playerClan.getId()))
+		if (!clanHandler.playerIsInClan(targetPlayer, playerClan.getId()))
 			return "&cThat player is not in your clan.";
 
 		clanHandler.kickClanMember(targetPlayer, executor); // Kick the player.

--- a/src/no/runsafe/clans/commands/LeaveClan.java
+++ b/src/no/runsafe/clans/commands/LeaveClan.java
@@ -17,12 +17,10 @@ public class LeaveClan extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String playerName = executor.getName();
-
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(executor))
 			return "&cYou are not in a clan.";
 
-		if (clanHandler.playerIsClanLeader(playerName))
+		if (clanHandler.playerIsClanLeader(executor))
 			return "&cYou cannot leave your clan, disband it first!";
 
 		clanHandler.removeClanMember(executor);

--- a/src/no/runsafe/clans/commands/LookupClan.java
+++ b/src/no/runsafe/clans/commands/LookupClan.java
@@ -24,12 +24,10 @@ public class LookupClan extends AsyncCommand
 		if (targetPlayer == null)
 			return "&cInvalid player!";
 
-		String playerName = targetPlayer.getName();
-
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(targetPlayer))
 			return "&cThat player is not in a clan.";
 
-		Clan clan = clanHandler.getPlayerClan(playerName);
+		Clan clan = clanHandler.getPlayerClan(targetPlayer);
 
 		return targetPlayer.getPrettyName() + "&f has been a member of " + clan.getId() + " for " + clanHandler.getPlayerJoinString(targetPlayer) + ".";
 	}

--- a/src/no/runsafe/clans/commands/PassLeadership.java
+++ b/src/no/runsafe/clans/commands/PassLeadership.java
@@ -19,21 +19,18 @@ public class PassLeadership extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String playerName = executor.getName();
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(executor))
 			return "&cYou are not in a clan.";
 
-		if (!clanHandler.playerIsClanLeader(playerName))
+		if (!clanHandler.playerIsClanLeader(executor))
 			return "&cYou are not the leader of your clan.";
 
 		IPlayer targetPlayer = parameters.getValue("player") ;
 		if (targetPlayer == null)
 			return "&cInvalid player";
 
-		String targetPlayerName = targetPlayer.getName();
-
-		Clan playerClan = clanHandler.getPlayerClan(playerName); // The clan of the player.
-		if (!clanHandler.playerIsInClan(targetPlayerName, playerClan.getId()))
+		Clan playerClan = clanHandler.getPlayerClan(executor); // The clan of the player.
+		if (!clanHandler.playerIsInClan(targetPlayer, playerClan.getId()))
 			return "&cThat player is not in your clan.";
 
 		clanHandler.changeClanLeader(playerClan.getId(), targetPlayer); // Change the leader.

--- a/src/no/runsafe/clans/commands/SetMotd.java
+++ b/src/no/runsafe/clans/commands/SetMotd.java
@@ -20,15 +20,13 @@ public class SetMotd extends PlayerAsyncCommand
 	@Override
 	public String OnAsyncExecute(IPlayer executor, IArgumentList parameters)
 	{
-		String playerName = executor.getName();
-
-		if (!clanHandler.playerIsInClan(playerName))
+		if (!clanHandler.playerIsInClan(executor))
 			return "&cYou are not in a clan.";
 
-		if (!clanHandler.playerIsClanLeader(playerName))
+		if (!clanHandler.playerIsClanLeader(executor))
 			return "&cYou are not the clan leader.";
 
-		Clan clan = clanHandler.getPlayerClan(playerName);
+		Clan clan = clanHandler.getPlayerClan(executor);
 		if (clan == null)
 			return "&cSomething just broke.";
 

--- a/src/no/runsafe/clans/commands/SetMotd.java
+++ b/src/no/runsafe/clans/commands/SetMotd.java
@@ -32,7 +32,7 @@ public class SetMotd extends PlayerAsyncCommand
 		if (clan == null)
 			return "&cSomething just broke.";
 
-		clanHandler.setClanMotd(clan.getId(), ChatColour.Strip(parameters.get("motd")));
+		clanHandler.setClanMotd(clan.getId(), ChatColour.Strip(parameters.getValue("motd")));
 		return null;
 	}
 

--- a/src/no/runsafe/clans/database/ClanInviteRepository.java
+++ b/src/no/runsafe/clans/database/ClanInviteRepository.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class ClanInviteRepository extends Repository
 {
@@ -24,7 +25,7 @@ public class ClanInviteRepository extends Repository
 
 		for (IRow row : database.query("SELECT `clanID`, `player` FROM `clan_invites`"))
 		{
-			IPlayer player = playerProvider.getPlayer(row.String("player"));
+			IPlayer player = playerProvider.getPlayer(UUID.fromString(row.String("player")));
 			if (!map.containsKey(player))
 				map.put(player, new ArrayList<>(0));
 
@@ -36,12 +37,12 @@ public class ClanInviteRepository extends Repository
 
 	public void clearPendingInvite(IPlayer player, String clanID)
 	{
-		database.execute("DELETE FROM `clan_invites` WHERE `player` = ? AND `clanID` = ?", player.getName(), clanID);
+		database.execute("DELETE FROM `clan_invites` WHERE `player` = ? AND `clanID` = ?", player.getUniqueId().toString(), clanID);
 	}
 
 	public void clearAllPendingInvites(IPlayer player)
 	{
-		database.execute("DELETE FROM `clan_invites` WHERE `player` = ?", player.getName());
+		database.execute("DELETE FROM `clan_invites` WHERE `player` = ?", player.getUniqueId().toString());
 	}
 
 	public void clearAllPendingInvitesForClan(String clanID)
@@ -51,7 +52,7 @@ public class ClanInviteRepository extends Repository
 
 	public void addInvite(IPlayer player, String clanID)
 	{
-		database.execute("INSERT IGNORE INTO `clan_invites` (`player`, `clanID`) VALUES(?, ?)", player, clanID);
+		database.execute("INSERT IGNORE INTO `clan_invites` (`player`, `clanID`) VALUES(?, ?)", player.getUniqueId().toString(), clanID);
 	}
 
 	@Nonnull
@@ -75,7 +76,15 @@ public class ClanInviteRepository extends Repository
 			")"
 		);
 
-		update.addQueries(String.format("ALTER TABLE `%s` MODIFY COLUMN player VARCHAR(36)", getTableName()));
+		update.addQueries(
+			String.format("ALTER TABLE `%s` MODIFY COLUMN player VARCHAR(36)", getTableName()),
+			String.format( // Player names -> Unique IDs
+				"UPDATE IGNORE `%s` SET `player` = " +
+					"COALESCE((SELECT `uuid` FROM player_db WHERE `name`=`%s`.`player`), `player`) " +
+					"WHERE length(`player`) != 36",
+				getTableName(), getTableName()
+			)
+		);
 
 		return update;
 	}

--- a/src/no/runsafe/clans/database/ClanInviteRepository.java
+++ b/src/no/runsafe/clans/database/ClanInviteRepository.java
@@ -1,8 +1,8 @@
 package no.runsafe.clans.database;
 
-import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.database.*;
 import no.runsafe.framework.api.player.IPlayer;
+import no.runsafe.framework.api.server.IPlayerProvider;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -12,10 +12,10 @@ import java.util.Map;
 
 public class ClanInviteRepository extends Repository
 {
-	public ClanInviteRepository(IDatabase database, IServer server)
+	public ClanInviteRepository(IDatabase database, IPlayerProvider playerProvider)
 	{
 		this.database = database;
-		this.server = server;
+		this.playerProvider = playerProvider;
 	}
 
 	public Map<IPlayer, List<String>> getPendingInvites()
@@ -24,7 +24,7 @@ public class ClanInviteRepository extends Repository
 
 		for (IRow row : database.query("SELECT `clanID`, `player` FROM `clan_invites`"))
 		{
-			IPlayer player = server.getPlayer(row.String("player"));
+			IPlayer player = playerProvider.getPlayer(row.String("player"));
 			if (!map.containsKey(player))
 				map.put(player, new ArrayList<>(0));
 
@@ -80,5 +80,5 @@ public class ClanInviteRepository extends Repository
 		return update;
 	}
 
-	private final IServer server;
+	private final IPlayerProvider playerProvider;
 }

--- a/src/no/runsafe/clans/database/ClanInviteRepository.java
+++ b/src/no/runsafe/clans/database/ClanInviteRepository.java
@@ -72,6 +72,8 @@ public class ClanInviteRepository extends Repository
 			")"
 		);
 
+		update.addQueries(String.format("ALTER TABLE `%s` MODIFY COLUMN player VARCHAR(36)", getTableName()));
+
 		return update;
 	}
 }

--- a/src/no/runsafe/clans/database/ClanMemberRepository.java
+++ b/src/no/runsafe/clans/database/ClanMemberRepository.java
@@ -74,6 +74,8 @@ public class ClanMemberRepository extends Repository
 
 		update.addQueries("ALTER TABLE `clan_members` ADD COLUMN `joined` DATETIME NOT NULL AFTER `member`;");
 
+		update.addQueries(String.format("ALTER TABLE `%s` MODIFY COLUMN member VARCHAR(36)", getTableName()));
+
 		return update;
 	}
 }

--- a/src/no/runsafe/clans/database/ClanMemberRepository.java
+++ b/src/no/runsafe/clans/database/ClanMemberRepository.java
@@ -72,7 +72,7 @@ public class ClanMemberRepository extends Repository
 				")"
 		);
 
-		update.addQueries("ALTER TABLE `clan_members` ADD COLUMN `joined` DATETIME NOT NULL AFTER `member`;");
+		update.addQueries("ALTER TABLE `clan_members` ADD COLUMN `joined` DATETIME NOT NULL AFTER `member`");
 
 		update.addQueries(String.format("ALTER TABLE `%s` MODIFY COLUMN member VARCHAR(36)", getTableName()));
 

--- a/src/no/runsafe/clans/database/ClanMemberRepository.java
+++ b/src/no/runsafe/clans/database/ClanMemberRepository.java
@@ -1,8 +1,8 @@
 package no.runsafe.clans.database;
 
-import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.database.*;
 import no.runsafe.framework.api.player.IPlayer;
+import no.runsafe.framework.api.server.IPlayerProvider;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nonnull;
@@ -13,10 +13,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class ClanMemberRepository extends Repository
 {
-	public ClanMemberRepository(IDatabase database, IServer server)
+	public ClanMemberRepository(IDatabase database, IPlayerProvider playerProvider)
 	{
 		this.database = database;
-		this.server = server;
+		this.playerProvider = playerProvider;
 	}
 
 	public Map<String, List<IPlayer>> getClanRosters()
@@ -28,7 +28,7 @@ public class ClanMemberRepository extends Repository
 			if (!rosters.containsKey(clanName))
 				rosters.put(clanName, new ArrayList<>(1));
 
-			rosters.get(clanName).add(server.getPlayer(row.String("member")));
+			rosters.get(clanName).add(playerProvider.getPlayer(row.String("member")));
 		}
 		return rosters;
 	}
@@ -81,5 +81,5 @@ public class ClanMemberRepository extends Repository
 		return update;
 	}
 
-	private final IServer server;
+	private final IPlayerProvider playerProvider;
 }

--- a/src/no/runsafe/clans/database/ClanMemberRepository.java
+++ b/src/no/runsafe/clans/database/ClanMemberRepository.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ClanMemberRepository extends Repository
@@ -28,7 +29,7 @@ public class ClanMemberRepository extends Repository
 			if (!rosters.containsKey(clanName))
 				rosters.put(clanName, new ArrayList<>(1));
 
-			rosters.get(clanName).add(playerProvider.getPlayer(row.String("member")));
+			rosters.get(clanName).add(playerProvider.getPlayer(UUID.fromString(row.String("member"))));
 		}
 		return rosters;
 	}

--- a/src/no/runsafe/clans/database/ClanRepository.java
+++ b/src/no/runsafe/clans/database/ClanRepository.java
@@ -80,11 +80,11 @@ public class ClanRepository extends Repository
 			")"
 		);
 
-		update.addQueries("ALTER TABLE `clans` ADD COLUMN `motd` VARCHAR(255) NOT NULL AFTER `created`;");
+		update.addQueries("ALTER TABLE `clans` ADD COLUMN `motd` VARCHAR(255) NOT NULL AFTER `created`");
 
 		update.addQueries("ALTER TABLE `clans`" +
 				"ADD COLUMN `clanKills` INT NOT NULL DEFAULT '0' AFTER `motd`," +
-				"ADD COLUMN `clanDeaths` INT NOT NULL DEFAULT '0' AFTER `clanKills`;");
+				"ADD COLUMN `clanDeaths` INT NOT NULL DEFAULT '0' AFTER `clanKills`");
 
 		update.addQueries("ALTER TABLE `clans`" +
 				"ADD COLUMN `dergonKills` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `clanDeaths`");

--- a/src/no/runsafe/clans/database/ClanRepository.java
+++ b/src/no/runsafe/clans/database/ClanRepository.java
@@ -1,6 +1,7 @@
 package no.runsafe.clans.database;
 
 import no.runsafe.clans.Clan;
+import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.database.*;
 import no.runsafe.framework.api.player.IPlayer;
 
@@ -10,9 +11,10 @@ import java.util.Map;
 
 public class ClanRepository extends Repository
 {
-	public ClanRepository(IDatabase database)
+	public ClanRepository(IDatabase database, IServer server)
 	{
 		this.database = database;
+		this.server = server;
 	}
 
 	public Map<String, Clan> getClans()
@@ -22,7 +24,7 @@ public class ClanRepository extends Repository
 		for (IRow row : database.query("SELECT `clanID`, `leader`, `motd`, `clanKills`, `clanDeaths`, `dergonKills` FROM `clans`"))
 		{
 			String clanName = row.String("clanID");
-			Clan clan = new Clan(clanName, row.String("leader"), row.String("motd"));
+			Clan clan = new Clan(clanName, server.getPlayer(row.String("leader")), row.String("motd"));
 			clan.addClanKills(row.Integer("clanKills")); // Add in kills stat
 			clan.addClanDeaths(row.Integer("clanDeaths")); // Add in deaths stat
 			clan.addDergonKills(row.Integer("dergonKills")); // Add dergon kills.
@@ -89,4 +91,6 @@ public class ClanRepository extends Repository
 
 		return update;
 	}
+
+	private final IServer server;
 }

--- a/src/no/runsafe/clans/database/ClanRepository.java
+++ b/src/no/runsafe/clans/database/ClanRepository.java
@@ -8,6 +8,7 @@ import no.runsafe.framework.api.server.IPlayerProvider;
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class ClanRepository extends Repository
 {
@@ -24,7 +25,7 @@ public class ClanRepository extends Repository
 		for (IRow row : database.query("SELECT `clanID`, `leader`, `motd`, `clanKills`, `clanDeaths`, `dergonKills` FROM `clans`"))
 		{
 			String clanName = row.String("clanID");
-			Clan clan = new Clan(clanName, playerProvider.getPlayer(row.String("leader")), row.String("motd"));
+			Clan clan = new Clan(clanName, playerProvider.getPlayer(UUID.fromString(row.String("leader"))), row.String("motd"));
 			clan.addClanKills(row.Integer("clanKills")); // Add in kills stat
 			clan.addClanDeaths(row.Integer("clanDeaths")); // Add in deaths stat
 			clan.addDergonKills(row.Integer("dergonKills")); // Add dergon kills.
@@ -45,12 +46,15 @@ public class ClanRepository extends Repository
 
 	public void changeClanLeader(String clanID, IPlayer leader)
 	{
-		database.execute("UPDATE `clans` SET `leader` = ? WHERE `clanID` = ?", leader.getName(), clanID);
+		database.execute("UPDATE `clans` SET `leader` = ? WHERE `clanID` = ?", leader.getUniqueId().toString(), clanID);
 	}
 
 	public void persistClan(Clan clan)
 	{
-		database.execute("INSERT INTO `clans` (`clanID`, `leader`, `created`, `motd`) VALUES(?, ?, NOW(), ?)", clan.getId(), clan.getLeader(), clan.getMotd());
+		database.execute(
+			"INSERT INTO `clans` (`clanID`, `leader`, `created`, `motd`) VALUES(?, ?, NOW(), ?)",
+			clan.getId(), clan.getLeader().getUniqueId().toString(), clan.getMotd()
+		);
 	}
 
 	public void updateStatistic(String clanID, String statistic, int value)
@@ -89,7 +93,15 @@ public class ClanRepository extends Repository
 		update.addQueries("ALTER TABLE `clans`" +
 				"ADD COLUMN `dergonKills` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `clanDeaths`");
 
-		update.addQueries(String.format("ALTER TABLE `%s` MODIFY COLUMN leader VARCHAR(36)", getTableName()));
+		update.addQueries(
+			String.format("ALTER TABLE `%s` MODIFY COLUMN leader VARCHAR(36)", getTableName()),
+			String.format( // Player names -> Unique IDs
+				"UPDATE IGNORE `%s` SET `leader` = " +
+					"COALESCE((SELECT `uuid` FROM player_db WHERE `name`=`%s`.`leader`), `leader`) " +
+					"WHERE length(`leader`) != 36",
+				getTableName(), getTableName()
+			)
+		);
 
 		return update;
 	}

--- a/src/no/runsafe/clans/database/ClanRepository.java
+++ b/src/no/runsafe/clans/database/ClanRepository.java
@@ -1,9 +1,9 @@
 package no.runsafe.clans.database;
 
 import no.runsafe.clans.Clan;
-import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.database.*;
 import no.runsafe.framework.api.player.IPlayer;
+import no.runsafe.framework.api.server.IPlayerProvider;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
@@ -11,10 +11,10 @@ import java.util.Map;
 
 public class ClanRepository extends Repository
 {
-	public ClanRepository(IDatabase database, IServer server)
+	public ClanRepository(IDatabase database, IPlayerProvider playerProvider)
 	{
 		this.database = database;
-		this.server = server;
+		this.playerProvider = playerProvider;
 	}
 
 	public Map<String, Clan> getClans()
@@ -24,7 +24,7 @@ public class ClanRepository extends Repository
 		for (IRow row : database.query("SELECT `clanID`, `leader`, `motd`, `clanKills`, `clanDeaths`, `dergonKills` FROM `clans`"))
 		{
 			String clanName = row.String("clanID");
-			Clan clan = new Clan(clanName, server.getPlayer(row.String("leader")), row.String("motd"));
+			Clan clan = new Clan(clanName, playerProvider.getPlayer(row.String("leader")), row.String("motd"));
 			clan.addClanKills(row.Integer("clanKills")); // Add in kills stat
 			clan.addClanDeaths(row.Integer("clanDeaths")); // Add in deaths stat
 			clan.addDergonKills(row.Integer("dergonKills")); // Add dergon kills.
@@ -94,5 +94,5 @@ public class ClanRepository extends Repository
 		return update;
 	}
 
-	private final IServer server;
+	private final IPlayerProvider playerProvider;
 }

--- a/src/no/runsafe/clans/database/ClanRepository.java
+++ b/src/no/runsafe/clans/database/ClanRepository.java
@@ -89,6 +89,8 @@ public class ClanRepository extends Repository
 		update.addQueries("ALTER TABLE `clans`" +
 				"ADD COLUMN `dergonKills` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `clanDeaths`");
 
+		update.addQueries(String.format("ALTER TABLE `%s` MODIFY COLUMN leader VARCHAR(36)", getTableName()));
+
 		return update;
 	}
 

--- a/src/no/runsafe/clans/handlers/CharterHandler.java
+++ b/src/no/runsafe/clans/handlers/CharterHandler.java
@@ -1,15 +1,27 @@
 package no.runsafe.clans.handlers;
 
+import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.framework.minecraft.Item;
 import no.runsafe.framework.minecraft.item.meta.RunsafeBook;
 import no.runsafe.framework.minecraft.item.meta.RunsafeMeta;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 public class CharterHandler
 {
+	/**
+	 * Constructor for handling clan charters.
+	 * @param server The server. Used for getting a player object from their username and or UUID.
+	 */
+	public CharterHandler(IServer server)
+	{
+		this.server = server;
+	}
+
 	public void givePlayerCharter(IPlayer player, String clanName)
 	{
 		RunsafeMeta charter = Item.Special.Crafted.WrittenBook.getItem(); // Create a book item.
@@ -17,7 +29,7 @@ public class CharterHandler
 		charter.addLore("§7Clan: " + clanName); // Append the clan name.
 		charter.addLore("§7Leader: " + player.getName()); // Append the clan leader.
 		charter.addLore("§fRight-click to sign the clan charter!"); // Add some info.
-		addCharterSign(charter, player.getName()); // Sign the charter.
+		addCharterSign(charter, player); // Sign the charter.
 
 		player.give(charter); // Give the player the charter.
 	}
@@ -33,9 +45,9 @@ public class CharterHandler
 		return getCharterValue(charter.getLore(), 0);
 	}
 
-	public String getLeaderName(RunsafeMeta charter)
+	public IPlayer getLeader(RunsafeMeta charter)
 	{
-		return getCharterValue(charter.getLore(), 1);
+		return getCharterSigns(charter).get(0);
 	}
 
 	private String getCharterValue(List<String> values, int index)
@@ -46,18 +58,26 @@ public class CharterHandler
 		return values.get(index).split("\\s")[1];
 	}
 
-	public List<String> getCharterSigns(RunsafeMeta item)
+	public List<IPlayer> getCharterSigns(RunsafeMeta item)
 	{
 		RunsafeBook charter = (RunsafeBook) item; // Convert item to a book.
 		if (charter.hasPages()) // Check we have some pages.
-			return charter.getPages(); // Return the pages.
+		{
+			List<String> charterPages = charter.getPages();
+			List<IPlayer> charterSigns = new ArrayList<IPlayer>(0);
+			for(String page : charterPages)
+				charterSigns.add(server.getPlayer(UUID.fromString(page)));
+			return charterSigns;
+		}
 
 		return Collections.emptyList(); // Return an empty thing.
 	}
 
-	public void addCharterSign(RunsafeMeta item, String playerName)
+	public void addCharterSign(RunsafeMeta item, IPlayer player)
 	{
 		RunsafeBook charter = (RunsafeBook) item; // Convert item to a book.
-		charter.addPages(playerName); // Add the sign to the charter.
+		charter.addPages(player.getUniqueId().toString()); // Add the sign to the charter.
 	}
+
+	private final IServer server;
 }

--- a/src/no/runsafe/clans/handlers/CharterHandler.java
+++ b/src/no/runsafe/clans/handlers/CharterHandler.java
@@ -1,7 +1,7 @@
 package no.runsafe.clans.handlers;
 
-import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.player.IPlayer;
+import no.runsafe.framework.api.server.IPlayerProvider;
 import no.runsafe.framework.minecraft.Item;
 import no.runsafe.framework.minecraft.item.meta.RunsafeBook;
 import no.runsafe.framework.minecraft.item.meta.RunsafeMeta;
@@ -15,11 +15,11 @@ public class CharterHandler
 {
 	/**
 	 * Constructor for handling clan charters.
-	 * @param server The server. Used for getting a player object from their username and or UUID.
+	 * @param playerProvider The provider of player objects.
 	 */
-	public CharterHandler(IServer server)
+	public CharterHandler(IPlayerProvider playerProvider)
 	{
-		this.server = server;
+		this.playerProvider = playerProvider;
 	}
 
 	public void givePlayerCharter(IPlayer player, String clanName)
@@ -66,7 +66,7 @@ public class CharterHandler
 			List<String> charterPages = charter.getPages();
 			List<IPlayer> charterSigns = new ArrayList<IPlayer>(0);
 			for(String page : charterPages)
-				charterSigns.add(server.getPlayer(UUID.fromString(page)));
+				charterSigns.add(playerProvider.getPlayer(UUID.fromString(page)));
 			return charterSigns;
 		}
 
@@ -79,5 +79,5 @@ public class CharterHandler
 		charter.addPages(player.getUniqueId().toString()); // Add the sign to the charter.
 	}
 
-	private final IServer server;
+	private final IPlayerProvider playerProvider;
 }

--- a/src/no/runsafe/clans/handlers/ClanHandler.java
+++ b/src/no/runsafe/clans/handlers/ClanHandler.java
@@ -326,9 +326,9 @@ public class ClanHandler implements IConfigurationChanged, IPlayerDataProvider, 
 		}
 	}
 
-	public void addDergonKill(String playerName)
+	public void addDergonKill(IPlayer player)
 	{
-		Clan clan = getPlayerClan(playerName);
+		Clan clan = getPlayerClan(player.getName());
 		if (clan != null)
 		{
 			String clanID = clan.getId();

--- a/src/no/runsafe/clans/handlers/ClanHandler.java
+++ b/src/no/runsafe/clans/handlers/ClanHandler.java
@@ -77,25 +77,25 @@ public class ClanHandler implements IConfigurationChanged, IPlayerDataProvider, 
 	@Override
 	public void OnPlayerCustomEvent(RunsafeCustomEvent event)
 	{
-		if (event instanceof ClanEvent)
+		if (!(event instanceof ClanEvent))
+			return;
+
+		Clan clan = ((ClanEvent) event).getClan();
+		IPlayer player = event.getPlayer();
+		if (event instanceof ClanJoinEvent)
 		{
-			Clan clan = ((ClanEvent) event).getClan();
-			IPlayer player = event.getPlayer();
-			if (event instanceof ClanJoinEvent)
-			{
-				joinClanChannel(player, clan.getId());
-				sendMessageToClan(clan.getId(), player.getPrettyName() + " has joined the clan.");
-			}
-			else if (event instanceof ClanLeaveEvent)
-			{
-				leaveClanChannel(player, clan.getId());
-				sendMessageToClan(clan.getId(), player.getPrettyName() + " has left the clan.");
-			}
-			else if (event instanceof ClanKickEvent)
-			{
-				leaveClanChannel(player, clan.getId());
-				sendMessageToClan(clan.getId(), player.getPrettyName() + " has been kicked from the clan by " + ((ClanKickEvent) event).getKicker().getPrettyName() + ".");
-			}
+			joinClanChannel(player, clan.getId());
+			sendMessageToClan(clan.getId(), player.getPrettyName() + " has joined the clan.");
+		}
+		else if (event instanceof ClanLeaveEvent)
+		{
+			leaveClanChannel(player, clan.getId());
+			sendMessageToClan(clan.getId(), player.getPrettyName() + " has left the clan.");
+		}
+		else if (event instanceof ClanKickEvent)
+		{
+			leaveClanChannel(player, clan.getId());
+			sendMessageToClan(clan.getId(), player.getPrettyName() + " has been kicked from the clan by " + ((ClanKickEvent) event).getKicker().getPrettyName() + ".");
 		}
 	}
 

--- a/src/no/runsafe/clans/handlers/ClanHandler.java
+++ b/src/no/runsafe/clans/handlers/ClanHandler.java
@@ -11,7 +11,6 @@ import no.runsafe.clans.events.ClanKickEvent;
 import no.runsafe.clans.events.ClanLeaveEvent;
 import no.runsafe.framework.api.IConfiguration;
 import no.runsafe.framework.api.IScheduler;
-import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.event.player.IPlayerCustomEvent;
 import no.runsafe.framework.api.event.player.IPlayerJoinEvent;
 import no.runsafe.framework.api.event.player.IPlayerQuitEvent;
@@ -40,10 +39,9 @@ import java.util.regex.Pattern;
 
 public class ClanHandler implements IConfigurationChanged, IPlayerDataProvider, IPlayerJoinEvent, IPlayerQuitEvent, IPlayerCustomEvent
 {
-	public ClanHandler(IConsole console, IServer server, IScheduler scheduler, ClanRepository clanRepository, ClanMemberRepository memberRepository, ClanInviteRepository inviteRepository, IChannelManager channelManager)
+	public ClanHandler(IConsole console, IScheduler scheduler, ClanRepository clanRepository, ClanMemberRepository memberRepository, ClanInviteRepository inviteRepository, IChannelManager channelManager)
 	{
 		this.console = console;
-		this.server = server;
 		this.scheduler = scheduler;
 		this.clanRepository = clanRepository;
 		this.memberRepository = memberRepository;
@@ -523,7 +521,6 @@ public class ClanHandler implements IConfigurationChanged, IPlayerDataProvider, 
 	private final Map<IPlayer, String> playerClanIndex = new ConcurrentHashMap<>(0);
 	private final Map<IPlayer, List<String>> playerInvites = new ConcurrentHashMap<>(0);
 	private final IConsole console;
-	private final IServer server;
 	private final IScheduler scheduler;
 	private final ClanRepository clanRepository;
 	private final ClanMemberRepository memberRepository;

--- a/src/no/runsafe/clans/handlers/RankingHandler.java
+++ b/src/no/runsafe/clans/handlers/RankingHandler.java
@@ -1,16 +1,16 @@
 package no.runsafe.clans.handlers;
 
 import no.runsafe.clans.Clan;
-import no.runsafe.framework.api.IConfiguration;
-import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
+import no.runsafe.clans.Config;
 
 import java.util.*;
 
-public class RankingHandler implements IConfigurationChanged
+public class RankingHandler
 {
-	public RankingHandler(ClanHandler clanHandler)
+	public RankingHandler(ClanHandler clanHandler, Config config)
 	{
 		this.clanHandler = clanHandler;
+		this.config = config;
 	}
 
 	public List<String> getRankingRoster()
@@ -21,7 +21,10 @@ public class RankingHandler implements IConfigurationChanged
 		for (Map.Entry<String, Clan> clanNode : clanMap.entrySet())
 		{
 			Clan clan = clanNode.getValue();
-			int score = ((clan.getMemberCount() * clanMemberScore) + (clan.getClanKills() * clanKillScore)) - (clan.getClanDeaths() * (clanKillScore / 2)) + (clan.getDergonKills() * clanDergonKillScore);
+			int score = (clan.getMemberCount() * config.getClanMemberScore())
+				+ (clan.getClanKills() * config.getClanKillScore())
+				- (clan.getClanDeaths() * (config.getClanKillScore() / 2))
+				+ (clan.getDergonKills() * config.getClanDergonKillScore());
 			roster.put(clan.getId(), score);
 		}
 
@@ -56,16 +59,6 @@ public class RankingHandler implements IConfigurationChanged
 		return sortedMap;
 	}
 
-	@Override
-	public void OnConfigurationChanged(IConfiguration config)
-	{
-		clanMemberScore = config.getConfigValueAsInt("ranking.clanMember");
-		clanKillScore = config.getConfigValueAsInt("ranking.clanKill");
-		clanDergonKillScore = config.getConfigValueAsInt("ranking.dergonKill");
-	}
-
-	private int clanMemberScore;
-	private int clanKillScore;
-	private int clanDergonKillScore;
+	private final Config config;
 	private final ClanHandler clanHandler;
 }

--- a/src/no/runsafe/clans/handlers/RankingHandler.java
+++ b/src/no/runsafe/clans/handlers/RankingHandler.java
@@ -1,16 +1,16 @@
 package no.runsafe.clans.handlers;
 
 import no.runsafe.clans.Clan;
-import no.runsafe.clans.Config;
+import no.runsafe.framework.api.IConfiguration;
+import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 
 import java.util.*;
 
-public class RankingHandler
+public class RankingHandler implements IConfigurationChanged
 {
-	public RankingHandler(ClanHandler clanHandler, Config config)
+	public RankingHandler(ClanHandler clanHandler)
 	{
 		this.clanHandler = clanHandler;
-		this.config = config;
 	}
 
 	public List<String> getRankingRoster()
@@ -21,10 +21,10 @@ public class RankingHandler
 		for (Map.Entry<String, Clan> clanNode : clanMap.entrySet())
 		{
 			Clan clan = clanNode.getValue();
-			int score = (clan.getMemberCount() * config.getClanMemberScore())
-				+ (clan.getClanKills() * config.getClanKillScore())
-				- (clan.getClanDeaths() * (config.getClanKillScore() / 2))
-				+ (clan.getDergonKills() * config.getClanDergonKillScore());
+			int score = (clan.getMemberCount() * clanMemberScore)
+				+ (clan.getClanKills() * clanKillScore)
+				- (clan.getClanDeaths() * (clanKillScore / 2))
+				+ (clan.getDergonKills() * clanDergonKillScore);
 			roster.put(clan.getId(), score);
 		}
 
@@ -59,6 +59,17 @@ public class RankingHandler
 		return sortedMap;
 	}
 
-	private final Config config;
+
+	@Override
+	public void OnConfigurationChanged(IConfiguration config)
+	{
+		clanMemberScore = config.getConfigValueAsInt("ranking.clanMember");
+		clanKillScore = config.getConfigValueAsInt("ranking.clanKill");
+		clanDergonKillScore = config.getConfigValueAsInt("ranking.dergonKill");
+	}
+
+	private int clanMemberScore;
+	private int clanKillScore;
+	private int clanDergonKillScore;
 	private final ClanHandler clanHandler;
 }

--- a/src/no/runsafe/clans/monitors/CombatMonitor.java
+++ b/src/no/runsafe/clans/monitors/CombatMonitor.java
@@ -39,10 +39,10 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 		String deadPlayerName = deadPlayer.getName();
 
 		// Check we tracked the player getting hit and they are in a clan!
-		if (!track.containsKey(deadPlayerName) || !clanHandler.playerIsInClan(deadPlayerName))
+		if (!track.containsKey(deadPlayer) || !clanHandler.playerIsInClan(deadPlayerName))
 			return;
 
-		String killerName = track.get(deadPlayerName).getAttacker().getName(); // Grab the name of the last player to hit them.
+		String killerName = track.get(deadPlayer).getAttacker().getName(); // Grab the name of the last player to hit them.
 		if (!clanHandler.playerIsInClan(killerName))
 			return;
 
@@ -99,21 +99,19 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 
 	private void registerHit(IPlayer victim, IPlayer attacker)
 	{
-		final String victimName = victim.getName();
-
 		// Check to see if we have a timer existing.
-		if (track.containsKey(victimName))
-			scheduler.cancelTask(track.get(victimName).getTimerID()); // Cancel existing timer.
+		if (track.containsKey(victim))
+			scheduler.cancelTask(track.get(victim).getTimerID()); // Cancel existing timer.
 		else
-			track.put(victimName, new CombatTrackingNode()); // Create blank node.
+			track.put(victim, new CombatTrackingNode()); // Create blank node.
 
 		// Update the node with new information.
-		track.get(victimName).setAttacker(attacker).setTimerID(scheduler.startAsyncTask(new Runnable()
+		track.get(victim).setAttacker(attacker).setTimerID(scheduler.startAsyncTask(new Runnable()
 		{
 			@Override
 			public void run()
 			{
-				track.remove(victimName); // Remove after 10 seconds.
+				track.remove(victim); // Remove after 10 seconds.
 			}
 		}, 10));
 	}
@@ -132,5 +130,5 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 	private final IScheduler scheduler;
 	private final ClanHandler clanHandler;
 	private final Config config;
-	private final ConcurrentHashMap<String, CombatTrackingNode> track = new ConcurrentHashMap<String, CombatTrackingNode>(0);
+	private final ConcurrentHashMap<IPlayer, CombatTrackingNode> track = new ConcurrentHashMap<>(0);
 }

--- a/src/no/runsafe/clans/monitors/CombatMonitor.java
+++ b/src/no/runsafe/clans/monitors/CombatMonitor.java
@@ -44,7 +44,7 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 		if (!track.containsKey(deadPlayerName) || !clanHandler.playerIsInClan(deadPlayerName))
 			return;
 
-		String killerName = track.get(deadPlayerName).getAttacker(); // Grab the name of the last player to hit them.
+		String killerName = track.get(deadPlayerName).getAttacker().getName(); // Grab the name of the last player to hit them.
 		if (!clanHandler.playerIsInClan(killerName))
 			return;
 
@@ -110,7 +110,7 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 			track.put(victimName, new CombatTrackingNode()); // Create blank node.
 
 		// Update the node with new information.
-		track.get(victimName).setAttacker(attacker.getName()).setTimerID(scheduler.startAsyncTask(new Runnable()
+		track.get(victimName).setAttacker(attacker).setTimerID(scheduler.startAsyncTask(new Runnable()
 		{
 			@Override
 			public void run()
@@ -122,7 +122,7 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 
 	private boolean isSamePlayer(IPlayer one, IPlayer two)
 	{
-		return one.getName().equalsIgnoreCase(two.getName());
+		return one.equals(two);
 	}
 
 	private IPlayer findPlayer(RunsafeLivingEntity entity)

--- a/src/no/runsafe/clans/monitors/CombatMonitor.java
+++ b/src/no/runsafe/clans/monitors/CombatMonitor.java
@@ -1,17 +1,16 @@
 package no.runsafe.clans.monitors;
 
 import no.runsafe.clans.Clan;
+import no.runsafe.clans.Config;
 import no.runsafe.clans.events.BackstabberEvent;
 import no.runsafe.clans.events.MutinyEvent;
 import no.runsafe.clans.handlers.ClanHandler;
-import no.runsafe.framework.api.IConfiguration;
 import no.runsafe.framework.api.IScheduler;
 import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.IUniverse;
 import no.runsafe.framework.api.entity.IProjectileSource;
 import no.runsafe.framework.api.event.entity.IEntityDamageByEntityEvent;
 import no.runsafe.framework.api.event.player.IPlayerDeathEvent;
-import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.framework.minecraft.entity.ProjectileEntity;
 import no.runsafe.framework.minecraft.entity.RunsafeEntity;
@@ -20,18 +19,17 @@ import no.runsafe.framework.minecraft.entity.RunsafeProjectile;
 import no.runsafe.framework.minecraft.event.entity.RunsafeEntityDamageByEntityEvent;
 import no.runsafe.framework.minecraft.event.player.RunsafePlayerDeathEvent;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEvent, IConfigurationChanged
+public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEvent
 {
-	public CombatMonitor(IServer server, IScheduler scheduler, ClanHandler clanHandler)
+	public CombatMonitor(IServer server, IScheduler scheduler, ClanHandler clanHandler, Config config)
 	{
 		this.server = server;
 		this.scheduler = scheduler;
 		this.clanHandler = clanHandler;
+		this.config = config;
 	}
 
 	@Override
@@ -78,7 +76,7 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 			return;
 
 		IUniverse universe = victim.getUniverse();
-		if (universe == null || !clanUniverses.contains(universe.getName()))
+		if (universe == null || !config.getClanUniverse().contains(universe.getName()))
 			return;
 
 		IPlayer source = null;
@@ -130,16 +128,9 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 		return null;
 	}
 
-	@Override
-	public void OnConfigurationChanged(IConfiguration config)
-	{
-		clanUniverses.clear();
-		Collections.addAll(clanUniverses, config.getConfigValueAsString("clanUniverse").split(","));
-	}
-
 	private final IServer server;
 	private final IScheduler scheduler;
 	private final ClanHandler clanHandler;
-	private List<String> clanUniverses = new ArrayList<String>(0);
+	private final Config config;
 	private final ConcurrentHashMap<String, CombatTrackingNode> track = new ConcurrentHashMap<String, CombatTrackingNode>(0);
 }

--- a/src/no/runsafe/clans/monitors/CombatMonitor.java
+++ b/src/no/runsafe/clans/monitors/CombatMonitor.java
@@ -116,16 +116,6 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 		}, 10));
 	}
 
-	private IPlayer findPlayer(RunsafeLivingEntity entity)
-	{
-		List<IPlayer> onlinePlayers = server.getOnlinePlayers();
-		for (IPlayer player : onlinePlayers)
-			if (entity != null && player != null && entity.getEntityId() == player.getEntityId())
-				return player;
-
-		return null;
-	}
-
 	private final IServer server;
 	private final IScheduler scheduler;
 	private final ClanHandler clanHandler;

--- a/src/no/runsafe/clans/monitors/CombatMonitor.java
+++ b/src/no/runsafe/clans/monitors/CombatMonitor.java
@@ -93,7 +93,7 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 				source = projectile.getShootingPlayer();
 		}
 
-		if (source == null || source.isVanished() || source.shouldNotSee(victim) || isSamePlayer(victim, source))
+		if (source == null || source.isVanished() || source.shouldNotSee(victim) || victim.equals(source))
 			return;
 
 		registerHit(victim, source); // Register the hit!
@@ -118,11 +118,6 @@ public class CombatMonitor implements IEntityDamageByEntityEvent, IPlayerDeathEv
 				track.remove(victimName); // Remove after 10 seconds.
 			}
 		}, 10));
-	}
-
-	private boolean isSamePlayer(IPlayer one, IPlayer two)
-	{
-		return one.equals(two);
 	}
 
 	private IPlayer findPlayer(RunsafeLivingEntity entity)

--- a/src/no/runsafe/clans/monitors/CombatTrackingNode.java
+++ b/src/no/runsafe/clans/monitors/CombatTrackingNode.java
@@ -1,13 +1,15 @@
 package no.runsafe.clans.monitors;
 
+import no.runsafe.framework.api.player.IPlayer;
+
 public class CombatTrackingNode
 {
-	public String getAttacker()
+	public IPlayer getAttacker()
 	{
 		return attacker;
 	}
 
-	public CombatTrackingNode setAttacker(String attacker)
+	public CombatTrackingNode setAttacker(IPlayer attacker)
 	{
 		this.attacker = attacker;
 		return this;
@@ -24,6 +26,6 @@ public class CombatTrackingNode
 		return this;
 	}
 
-	private String attacker;
+	private IPlayer attacker;
 	private int timerID;
 }

--- a/src/no/runsafe/clans/monitors/DergonKillMonitor.java
+++ b/src/no/runsafe/clans/monitors/DergonKillMonitor.java
@@ -15,7 +15,7 @@ public class DergonKillMonitor implements IPlayerCustomEvent
 	public void OnPlayerCustomEvent(RunsafeCustomEvent event)
 	{
 		if (event.getEvent().equals("runsafe.dergon.slay"))
-			handler.addDergonKill(event.getPlayer().getName());
+			handler.addDergonKill(event.getPlayer());
 	}
 
 	private final ClanHandler handler;

--- a/src/no/runsafe/clans/monitors/PlayerMonitor.java
+++ b/src/no/runsafe/clans/monitors/PlayerMonitor.java
@@ -51,9 +51,9 @@ public class PlayerMonitor implements IPlayerRightClick
 			return false;
 		}
 
-		List<String> charterSigns = charterHandler.getCharterSigns(usingItem);
+		List<IPlayer> charterSigns = charterHandler.getCharterSigns(usingItem);
 
-		if (charterSigns.contains(playerName))
+		if (charterSigns.contains(player))
 		{
 			player.sendColouredMessage("&cYou have already signed this charter.");
 			player.closeInventory();
@@ -63,15 +63,15 @@ public class PlayerMonitor implements IPlayerRightClick
 		// If we have less than 2 signs on the charter, we should sign it!
 		if (charterSigns.size() < 2)
 		{
-			charterHandler.addCharterSign(usingItem, playerName);
+			charterHandler.addCharterSign(usingItem, player);
 			player.sendColouredMessage("&aYou have signed the charter!");
 		}
 		else
 		{
 			// Make sure all signs are valid.
-			for (String signedPlayer : charterSigns)
+			for (IPlayer signedPlayer : charterSigns)
 			{
-				if (clanHandler.playerIsInClan(signedPlayer))
+				if (clanHandler.playerIsInClan(signedPlayer.getName()))
 				{
 					player.sendColouredMessage("&cOne or more of the signatures on this charter are invalid, get more!");
 					player.closeInventory();
@@ -86,12 +86,12 @@ public class PlayerMonitor implements IPlayerRightClick
 				return false;
 			}
 
-			clanHandler.createClan(clanName, charterHandler.getLeaderName(usingItem)); // Forge the clan!
+			clanHandler.createClan(clanName, charterHandler.getLeader(usingItem).getName()); // Forge the clan!
 
 			// Add all players on the charter to the clan if they are not already in a clan.
-			for (String signedPlayer : charterSigns)
-				if (!clanHandler.playerIsInClan(signedPlayer))
-					clanHandler.addClanMember(clanName, signedPlayer);
+			for (IPlayer signedPlayer : charterSigns)
+				if (!clanHandler.playerIsInClan(signedPlayer.getName()))
+					clanHandler.addClanMember(clanName, signedPlayer.getName());
 
 			clanHandler.addClanMember(clanName, player.getName()); // Add the signing player to the clan.
 			clanHandler.sendMessageToClan(clanName, "Your clan has been formed!");

--- a/src/no/runsafe/clans/monitors/PlayerMonitor.java
+++ b/src/no/runsafe/clans/monitors/PlayerMonitor.java
@@ -1,7 +1,9 @@
 package no.runsafe.clans.monitors;
 
+import no.runsafe.clans.Config;
 import no.runsafe.clans.handlers.CharterHandler;
 import no.runsafe.clans.handlers.ClanHandler;
+import no.runsafe.framework.api.IUniverse;
 import no.runsafe.framework.api.block.IBlock;
 import no.runsafe.framework.api.event.player.IPlayerRightClick;
 import no.runsafe.framework.api.player.IPlayer;
@@ -12,15 +14,21 @@ import java.util.List;
 
 public class PlayerMonitor implements IPlayerRightClick
 {
-	public PlayerMonitor(CharterHandler charterHandler, ClanHandler clanHandler)
+	public PlayerMonitor(CharterHandler charterHandler, ClanHandler clanHandler, Config config)
 	{
 		this.charterHandler = charterHandler;
 		this.clanHandler = clanHandler;
+		this.config = config;
 	}
 
 	@Override
 	public boolean OnPlayerRightClick(IPlayer player, RunsafeMeta usingItem, IBlock targetBlock)
 	{
+		// Check we're in the right universe.
+		IUniverse universe = player.getUniverse();
+		if (universe == null || !config.getClanUniverse().contains(universe.getName()))
+			return true;
+
 		// Check we are holding a charter.
 		if (usingItem == null || !usingItem.is(Item.Special.Crafted.WrittenBook) || !charterHandler.itemIsCharter(usingItem))
 			return true;
@@ -103,4 +111,5 @@ public class PlayerMonitor implements IPlayerRightClick
 
 	private final CharterHandler charterHandler;
 	private final ClanHandler clanHandler;
+	private final Config config;
 }

--- a/src/no/runsafe/clans/monitors/PlayerMonitor.java
+++ b/src/no/runsafe/clans/monitors/PlayerMonitor.java
@@ -22,84 +22,83 @@ public class PlayerMonitor implements IPlayerRightClick
 	public boolean OnPlayerRightClick(IPlayer player, RunsafeMeta usingItem, IBlock targetBlock)
 	{
 		// Check we are holding a charter.
-		if (usingItem != null && usingItem.is(Item.Special.Crafted.WrittenBook) && charterHandler.itemIsCharter(usingItem))
+		if (usingItem == null || !usingItem.is(Item.Special.Crafted.WrittenBook) || !charterHandler.itemIsCharter(usingItem))
+			return true;
+
+		String playerName = player.getName(); // Name of the player using the book.
+		if (clanHandler.playerIsInClan(playerName))
 		{
-			String playerName = player.getName(); // Name of the player using the book.
-			if (clanHandler.playerIsInClan(playerName))
-			{
-				player.sendColouredMessage("&cYou are already in a clan, you cannot sign this.");
-				player.closeInventory();
-				return false;
-			}
-
-			String clanName = charterHandler.getClanName(usingItem); // Grab the clan name from the book.
-
-			// Check we have been given a valid clan name.
-			if (clanHandler.isInvalidClanName(clanName))
-			{
-				player.sendColouredMessage(String.format("&c'%s' is not a valid clan tag. A clan tag must be three characters using characters A-Z.", clanName));
-				player.closeInventory();
-				return false;
-			}
-
-			// If the clan already exists, just tell them it can't happen.
-			if (clanHandler.clanExists(clanName))
-			{
-				player.sendColouredMessage(String.format("&cA clan named '%s' already exists.", clanName));
-				player.closeInventory();
-				return false;
-			}
-
-			List<String> charterSigns = charterHandler.getCharterSigns(usingItem);
-
-			if (charterSigns.contains(playerName))
-			{
-				player.sendColouredMessage("&cYou have already signed this charter.");
-				player.closeInventory();
-				return false;
-			}
-
-			// If we have less than 2 signs on the charter, we should sign it!
-			if (charterSigns.size() < 2)
-			{
-				charterHandler.addCharterSign(usingItem, playerName);
-				player.sendColouredMessage("&aYou have signed the charter!");
-			}
-			else
-			{
-				// Make sure all signs are valid.
-				for (String signedPlayer : charterSigns)
-				{
-					if (clanHandler.playerIsInClan(signedPlayer))
-					{
-						player.sendColouredMessage("&cOne or more of the signatures on this charter are invalid, get more!");
-						player.closeInventory();
-						return false;
-					}
-				}
-
-				if (clanHandler.playerIsInClan(playerName))
-				{
-					player.sendColouredMessage("&cYou are already in a clan!");
-					player.closeInventory();
-					return false;
-				}
-
-				clanHandler.createClan(clanName, charterHandler.getLeaderName(usingItem)); // Forge the clan!
-
-				// Add all players on the charter to the clan if they are not already in a clan.
-				for (String signedPlayer : charterSigns)
-					if (!clanHandler.playerIsInClan(signedPlayer))
-						clanHandler.addClanMember(clanName, signedPlayer);
-
-				clanHandler.addClanMember(clanName, player.getName()); // Add the signing player to the clan.
-				clanHandler.sendMessageToClan(clanName, "Your clan has been formed!");
-				player.removeExactItem(usingItem); // Remove the charter.
-			}
+			player.sendColouredMessage("&cYou are already in a clan, you cannot sign this.");
 			player.closeInventory();
 			return false;
 		}
-		return true;
+
+		String clanName = charterHandler.getClanName(usingItem); // Grab the clan name from the book.
+
+		// Check we have been given a valid clan name.
+		if (clanHandler.isInvalidClanName(clanName))
+		{
+			player.sendColouredMessage(String.format("&c'%s' is not a valid clan tag. A clan tag must be three characters using characters A-Z.", clanName));
+			player.closeInventory();
+			return false;
+		}
+
+		// If the clan already exists, just tell them it can't happen.
+		if (clanHandler.clanExists(clanName))
+		{
+			player.sendColouredMessage(String.format("&cA clan named '%s' already exists.", clanName));
+			player.closeInventory();
+			return false;
+		}
+
+		List<String> charterSigns = charterHandler.getCharterSigns(usingItem);
+
+		if (charterSigns.contains(playerName))
+		{
+			player.sendColouredMessage("&cYou have already signed this charter.");
+			player.closeInventory();
+			return false;
+		}
+
+		// If we have less than 2 signs on the charter, we should sign it!
+		if (charterSigns.size() < 2)
+		{
+			charterHandler.addCharterSign(usingItem, playerName);
+			player.sendColouredMessage("&aYou have signed the charter!");
+		}
+		else
+		{
+			// Make sure all signs are valid.
+			for (String signedPlayer : charterSigns)
+			{
+				if (clanHandler.playerIsInClan(signedPlayer))
+				{
+					player.sendColouredMessage("&cOne or more of the signatures on this charter are invalid, get more!");
+					player.closeInventory();
+					return false;
+				}
+			}
+
+			if (clanHandler.playerIsInClan(playerName))
+			{
+				player.sendColouredMessage("&cYou are already in a clan!");
+				player.closeInventory();
+				return false;
+			}
+
+			clanHandler.createClan(clanName, charterHandler.getLeaderName(usingItem)); // Forge the clan!
+
+			// Add all players on the charter to the clan if they are not already in a clan.
+			for (String signedPlayer : charterSigns)
+				if (!clanHandler.playerIsInClan(signedPlayer))
+					clanHandler.addClanMember(clanName, signedPlayer);
+
+			clanHandler.addClanMember(clanName, player.getName()); // Add the signing player to the clan.
+			clanHandler.sendMessageToClan(clanName, "Your clan has been formed!");
+			player.removeExactItem(usingItem); // Remove the charter.
+		}
+		player.closeInventory();
+		return false;
 	}
 
 	private final CharterHandler charterHandler;

--- a/src/no/runsafe/clans/monitors/PlayerMonitor.java
+++ b/src/no/runsafe/clans/monitors/PlayerMonitor.java
@@ -33,8 +33,7 @@ public class PlayerMonitor implements IPlayerRightClick
 		if (usingItem == null || !usingItem.is(Item.Special.Crafted.WrittenBook) || !charterHandler.itemIsCharter(usingItem))
 			return true;
 
-		String playerName = player.getName(); // Name of the player using the book.
-		if (clanHandler.playerIsInClan(playerName))
+		if (clanHandler.playerIsInClan(player))
 		{
 			player.sendColouredMessage("&cYou are already in a clan, you cannot sign this.");
 			player.closeInventory();
@@ -79,7 +78,7 @@ public class PlayerMonitor implements IPlayerRightClick
 			// Make sure all signs are valid.
 			for (IPlayer signedPlayer : charterSigns)
 			{
-				if (clanHandler.playerIsInClan(signedPlayer.getName()))
+				if (clanHandler.playerIsInClan(signedPlayer))
 				{
 					player.sendColouredMessage("&cOne or more of the signatures on this charter are invalid, get more!");
 					player.closeInventory();
@@ -87,21 +86,21 @@ public class PlayerMonitor implements IPlayerRightClick
 				}
 			}
 
-			if (clanHandler.playerIsInClan(playerName))
+			if (clanHandler.playerIsInClan(player))
 			{
 				player.sendColouredMessage("&cYou are already in a clan!");
 				player.closeInventory();
 				return false;
 			}
 
-			clanHandler.createClan(clanName, charterHandler.getLeader(usingItem).getName()); // Forge the clan!
+			clanHandler.createClan(clanName, charterHandler.getLeader(usingItem)); // Forge the clan!
 
 			// Add all players on the charter to the clan if they are not already in a clan.
 			for (IPlayer signedPlayer : charterSigns)
-				if (!clanHandler.playerIsInClan(signedPlayer.getName()))
-					clanHandler.addClanMember(clanName, signedPlayer.getName());
+				if (!clanHandler.playerIsInClan(signedPlayer))
+					clanHandler.addClanMember(clanName, signedPlayer);
 
-			clanHandler.addClanMember(clanName, player.getName()); // Add the signing player to the clan.
+			clanHandler.addClanMember(clanName, player); // Add the signing player to the clan.
 			clanHandler.sendMessageToClan(clanName, "Your clan has been formed!");
 			player.removeExactItem(usingItem); // Remove the charter.
 		}


### PR DESCRIPTION
- Old clan charters are now incompatible.
- Clan charters can only be used in survival to prevent creative players from spawning in counterfeit clan charters and creating a clan with arbitrary players.